### PR TITLE
Fixed missing Content-Type header

### DIFF
--- a/src/Unicorn/ControlPanel/UnicornControlPanelPipelineProcessor.cs
+++ b/src/Unicorn/ControlPanel/UnicornControlPanelPipelineProcessor.cs
@@ -53,6 +53,7 @@ namespace Unicorn.ControlPanel
 
 			if (!Authorization.IsAllowed)
 			{
+				context.Response.AddHeader("Content-Type", "text/html");
 				controls = GetDefaultControls();
 			}
 			else


### PR DESCRIPTION
A correct `Content-Type` header was not provided when showing the Access
Denied page.
When used in environments with `X-Content-Type-Options: nosniff`, the
browser would simple show the HTML of the page