### PR TITLE
Config file documentation review

### DIFF
--- a/src/Unicorn/Standard Config Files/Unicorn.AutoPublish.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.AutoPublish.config
@@ -2,9 +2,9 @@
 	Unicorn Auto Publish Configuration
 
 	This file configures the Unicorn serialization system to automatically publish items that it syncs.
-	
+
 	This file should be removed on content delivery environments.
-	
+
 	http://github.com/kamsar/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
@@ -14,7 +14,7 @@
 				<!-- at the end of each configuration's sync, we throw the items it changed into ManualPublishQueueHandler's queue -->
 				<processor type="Unicorn.Pipelines.UnicornSyncComplete.AddSyncedItemsToPublishQueue, Unicorn" />
 			</unicornSyncComplete>
-		
+
 			<unicornSyncEnd>
 				<!-- when all configurations have synced, fire off a publish that processes the queue we've accumulated -->
 				<processor type="Unicorn.Pipelines.UnicornSyncEnd.TriggerAutoPublishSyncedItems, Unicorn">
@@ -25,10 +25,10 @@
 					</TargetDatabases>
 				</processor>
 			</unicornSyncEnd>
-		
+
 			<publish>
-				<!-- 
-					This handler manually injects arbitrary items into the publish queue so that the next publish to occur will cause the injected items to get published 
+				<!--
+					This handler manually injects arbitrary items into the publish queue so that the next publish to occur will cause the injected items to get published. 
 					See http://www.velir.com/blog/index.php/2013/11/22/how-to-create-a-custom-publish-queue-in-sitecore/ et. al.
 				-->
 				<processor patch:after="*[@type='Sitecore.Publishing.Pipelines.Publish.AddItemsToQueue, Sitecore.Kernel']" type="Unicorn.Publishing.ManualPublishQueueHandler, Unicorn"/>

--- a/src/Unicorn/Standard Config Files/Unicorn.Configs.Default.example
+++ b/src/Unicorn/Standard Config Files/Unicorn.Configs.Default.example
@@ -3,20 +3,20 @@
 
 	This is an example of how to configure a basic Unicorn configuration using your own config patch file.
 	Copy this file to use as a basis for your own configuration definitions.
-	
+
 	Configuration definition patches should be present on all environments Unicorn is present on.
-	
+
 	See Unicorn.config for commentary on how configurations operate, or https://github.com/kamsar/Unicorn/blob/master/README.md
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
 	<sitecore>
 		<unicorn>
 			<configurations>
-				<!-- 
+				<!--
 					The default configuration defines a somewhat sane set of default dev artifacts to serialize.
-					You will probably want to customize the includes and excludes. Consider serializing a multisite installation 
+					You will probably want to customize the includes and excludes. Consider serializing a multisite installation
 					with a configuration for each site, as opposed to all templates and layout in one as defined below.
-					
+
 					Configurations can override the default dependencies defined in Unicorn.config's <defaults> to apply
 					custom behaviors to specific configurations.
 				-->
@@ -25,22 +25,22 @@
 						<!--
 							Each include can also exclude specific subitems by path:
 							<exclude path="/sitecore/content"/>
-							
+
 							Excludes may also exclude all children at once by adding a trailing slash, e.g. this would include the root /sitecore item but no children
 							<include path="/sitecore">
 								<exclude path="/sitecore/" />
 							</include>
-							
+
 							NOTE: after changing what is included or excluded, you should reserialize all items, or at least the added items
 							NOTE: the "name" attribute controls the folder name the items will go into (for SFS). If unspecified, the last path segment is used. Names must be unique across the configuration.
 						-->
-						
+
 						<!-- Core DB items: common customization locations for custom apps, custom experience buttons, etc -->
 						<include database="core" path="/sitecore/system/Field types"/>
 						<include name="Core Settings" database="core" path="/sitecore/system/Settings" />
 						<include name="Core Start Menu" database="core" path="/sitecore/content/Documents and settings/All users"/>
 						<include name="Core Applications" database="core" path="/sitecore/content/Applications"/>
-						
+
 						<!-- Master Layout items (and renderings, sublayouts, etc) -->
 						<include database="master" path="/sitecore/layout">
 							<exclude path="/sitecore/layout/Simulators" />
@@ -52,7 +52,7 @@
 							<exclude path="/sitecore/layout/Sublayouts/Social" />
 							<exclude path="/sitecore/layout/Placeholder Settings/App Center Sync" />
 						</include>
-						
+
 						<!-- Master System items (global settings, workflows, etc) -->
 						<include database="master" path="/sitecore/system">
 							<exclude path="/sitecore/system/Aliases"/>
@@ -66,8 +66,8 @@
 							<exclude path="/sitecore/system/Tasks/Schedules" />
 							<exclude path="/sitecore/system/Modules/PowerShell/Settings/ISE/sitecore" />
 						</include>
-						
-						<!-- 	Master Templates (except system stuff) -->
+
+						<!-- Master Templates (except system stuff) -->
 						<include database="master" path="/sitecore/templates">
 							<exclude path="/sitecore/templates/System"/>
 							<exclude path="/sitecore/templates/App Center Sync"/>

--- a/src/Unicorn/Standard Config Files/Unicorn.Configs.NewItemsOnly.example
+++ b/src/Unicorn/Standard Config Files/Unicorn.Configs.NewItemsOnly.example
@@ -1,20 +1,20 @@
 <!--
 	Unicorn.Configs.NewItemsOnly.config
 
-	This is an example of how to configure a a Unicorn configuration that overrides the default sync behavior
+	This is an example of how to configure a Unicorn configuration that overrides the default sync behavior
 	to only load items that are new on disk into Sitecore. This can be handy if you want to only deploy some content items
 	once and thereafter cede control over them to content editors.
-	
+
 	Configuration definition patches should be present on all environments Unicorn is present on.
-	
+
 	See Unicorn.config for commentary on how configurations operate, or https://github.com/kamsar/Unicorn/blob/master/README.md
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
 	<sitecore>
 		<unicorn>
 			<configurations>
-				<!-- 
-						This is an example of how to configure a a Unicorn configuration that overrides the default Evaluator
+				<!--
+						This is an example of how to configure a Unicorn configuration that overrides the default Evaluator
 						(the code that decides what to do when item differences are found) so that instead of having the disk be the master
 						and all changes syncing to that state, only brand new items are synced. Existing items, deleted items, or changed items
 						are ignored because we've overridden the default Evaluator.
@@ -22,14 +22,14 @@
 				<configuration name="Sample New Items Only Configuration">
 					<!-- swap the evaluator to the different implementation (see <defaults> in Unicorn.config for a full list of things you can replace like this) -->
 					<evaluator type="Unicorn.Evaluators.NewItemOnlyEvaluator, Unicorn" singleInstance="true"/>
-					
+
 					<!--
-						Note: when using custom evaluators keep transparent sync OFF for those configurations (the line below). 
+						Note: when using custom evaluators keep transparent sync OFF for those configurations (the line below).
 						The transparent sync operates by reading from the serialization store directly.
 						In other words transparent sync always acts like SerializedAsMasterEvaluator because disk is LITERALLY the master.
 					-->
 					<dataProviderConfiguration enableTransparentSync="false" type="Unicorn.Data.DataProvider.DefaultUnicornDataProviderConfiguration, Unicorn" />
-				
+
 					<predicate type="Unicorn.Predicates.SerializationPresetPredicate, Unicorn" singleInstance="true">
 						<include database="master" path="/sitecore/content/global-settings" />
 					</predicate>

--- a/src/Unicorn/Standard Config Files/Unicorn.DataProvider.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.DataProvider.config
@@ -2,19 +2,19 @@
 	Unicorn Data Provider Configuration
 
 	This file configures the Unicorn data provider. The data provider writes updated serialized items to disk when they are changed.
-	
+
 	This file should be removed in ANY deployed instance (CE or CD) that does not act as a source for serialized item updates.
 	Generally speaking that's anywhere other than a developer workstation, so your CI process (you have one, right?) should remove this file during the build.
-	
+
 	http://github.com/kamsar/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
 	<sitecore>
 		<dataProviders>
-			<!-- 
+			<!--
 				Register the Unicorn data provider for use. If a database hooks to the Unicorn data provider it will
 				automatically write changes to the database that match any configured predicate into the serialization provider.
-				
+
 				Changes that only affect Revision, Modified, or any fields ignored by FieldPredicates will be ignored.
 			-->
 			<unicorn type="Unicorn.Data.DataProvider.Unicorn$(database)DataProvider, Unicorn">
@@ -23,13 +23,14 @@
 			</unicorn>
 		</dataProviders>
 
-		<!-- 
-			Hook the Unicorn Data Provider into the master and core databases.
-			If you're not syncing anything in core you can safely unregister it from here.
-			If you want to sync something to another database register it here.
-			
-			It's safe to remove this config section on any environment where you are not collecting item changes,
-			which may mean anywhere other than local development sites. This will avoid any performance hit from writing unused serialized files.
+		<!--
+			Hook the Unicorn Data Provider into the master and core databases. If you're not
+			syncing anything in core you can safely unregister it from here. If you want to
+			sync something to another database register	it here.
+
+			It's safe to remove this config section on any environment where you are not
+			collecting item changes, which may mean anywhere other than local development
+			sites. This will avoid any performance hit from writing unused serialized files.
 		-->
 		<databases>
 			<database id="master">

--- a/src/Unicorn/Standard Config Files/Unicorn.Deployed.config.disabled
+++ b/src/Unicorn/Standard Config Files/Unicorn.Deployed.config.disabled
@@ -2,25 +2,25 @@
 	Unicorn Deployed Configuration
 
 	This file configures Unicorn to throw up warnings and prompts when saving items that are included by Unicorn.
-	
+
 	This is appropriate to use in a CE environment where Unicorn items are deployed to, as it will warn careless editors to not change items controlled by Unicorn.
 	Do not enable this in a development environment.
-	
+
 	http://github.com/kamsar/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
 	<sitecore>
 		<processors>
 			<saveUI>
-				<!-- 
-					This processor will throw up a warning if you try to save an item that is controlled by Unicorn when it has been deployed
+				<!--
+					This processor will throw up a warning if you try to save an item that is controlled by Unicorn when it has been deployed.
 				-->
 				<processor patch:before="*[@type='Unicorn.UI.Pipelines.SaveUi.SerializationConflictProcessor, Unicorn']" mode="on" type="Unicorn.UI.Pipelines.SaveUi.SerializationChangeBlocker, Unicorn"/>
 			</saveUI>
 		</processors>
 
 		<settings>
-			<!-- Changes the text of the warning for items that are serialized by Unicorn -->
+			<!-- Changes the text of the warning for items that are serialized by Unicorn. -->
 			<setting name="Unicorn.DevMode" value="false" />
 		</settings>
 	</sitecore>

--- a/src/Unicorn/Standard Config Files/Unicorn.Remote.config.disabled
+++ b/src/Unicorn/Standard Config Files/Unicorn.Remote.config.disabled
@@ -3,11 +3,11 @@
 
 	This file enables the Unicorn control panel remote API. This is used by the Unicorn Control Panel extension for Visual Studio by Andrii Snigyr (@BerserkerDotNet):
 	https://visualstudiogallery.msdn.microsoft.com/64439022-f470-422a-b663-fbb89aaf6e86
-	
+
 	If you are not using the VS integration, you can safely remove or disable this patch file. To enable this patch file simply remove the .disabled.
-	
+
 	This file should be present only on development environments that are using the VS plugin.
-	
+
 	http://github.com/kamsar/Unicorn
 	https://github.com/BerserkerDotNet/Unicorn.VisualStudio
 -->

--- a/src/Unicorn/Standard Config Files/Unicorn.UI.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.UI.config
@@ -2,18 +2,18 @@
 	Unicorn Control Panel Configuration
 
 	This file configures the Unicorn control panel, which enables syncing. This file should be removed when deploying to Content Delivery environments.
-	
+
 	http://github.com/kamsar/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
 	<sitecore>
 		<processors>
 			<saveUI>
-				<!-- 
+				<!--
 					This processor will compare the pre-save version of the item to what's serialized on disk
 					and throw a warning box if they do not match. This helps prevent overwriting of data if you
 					happen to forget to sync changes into Sitecore.
-					
+
 					All configurations are evaluated by the processor. Fields ignored by the FieldPredicate are ignored.
 				-->
 				<processor patch:before="*[@type='Sitecore.Pipelines.Save.Save, Sitecore.Kernel']" mode="on" type="Unicorn.UI.Pipelines.SaveUi.SerializationConflictProcessor, Unicorn"/>
@@ -22,8 +22,8 @@
 
 		<pipelines>
 			<httpRequestBegin>
-				<!-- 
-					This pipeline handler shows the Unicorn control panel. You can customize the URL the control panel lives at by changing the activationUrl. 
+				<!--
+					This pipeline handler shows the Unicorn control panel. You can customize the URL the control panel lives at by changing the activationUrl.
 					The activationUrl must be a URL that the Sitecore pipeline won't ignore (e.g. .aspx, .ashx, etc)
 				-->
 				<processor patch:after="*[@type='Sitecore.Pipelines.HttpRequest.UserResolver, Sitecore.Kernel']" type="Unicorn.ControlPanel.UnicornControlPanelPipelineProcessor">
@@ -39,10 +39,10 @@
 		</pipelines>
 
 		<commands>
-			<!-- 
+			<!--
 				Replaces Sitecore admin serialization commands (on the Developer tab of the ribbon) with Unicorn ones.
 				With these installed, if you serialize, load, or revert trees or items in the context of items that
-				are included in Unicorn, regular Sitecore serialization will be replaced with Unicorn reserialization 
+				are included in Unicorn, regular Sitecore serialization will be replaced with Unicorn reserialization
 				or Unicorn syncing of that item (or tree) instead. Note that "update" and "revert" are the same thing
 				in the context of Unicorn - a sync.
 			-->

--- a/src/Unicorn/Standard Config Files/Unicorn.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.config
@@ -1,68 +1,80 @@
 <!--
 	Unicorn.config
 
-	This file configures the Unicorn serialization system, which enables automatic synchronization of Sitecore items
-	without packages or manual merging.
-	
-	This file should be present on all environments Unicorn is present on. It is safe to leave on Content Delivery servers, as it changes no stock Sitecore configuration.
-	
+	This file configures the Unicorn serialization system, which enables automatic
+	synchronization of Sitecore items without packages or manual merging.
+
+	This file should be present on all environments Unicorn is present on. It is
+	safe to leave on Content Delivery servers, as it changes no stock Sitecore
+	configuration.
+
 	http://github.com/kamsar/Unicorn
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
 	<sitecore>
 		<unicorn>
-			<!-- 
+			<!--
 				Configurations
-				
-				These define sets  of configuration that Unicorn can run. For example, you might want to serialize
-				certain items differently, or segregate configurations so that critical ones can run separately
-				from non-essential ones to save time.
-				
+
+				These define sets of configuration that Unicorn can run. For example, you might
+				want to serialize certain items differently, or segregate configurations so
+				that critical ones can run separately from non-essential ones to save time.
+
 				See the README here for more information:
 				https://github.com/kamsar/Unicorn/blob/master/README.md
-				
-				If you're familiar with DI and IoC containers, each configuration is effectively a dependency container which inherits from the global container defined in <defaults>.
-				
-				NOTE: Your own configurations should be defined in config patch files. See Unicorn.Configs.Default.example for a baseline you can make your own from.
+
+				If you're familiar with DI and IoC containers, each configuration is effectively
+				a dependency container which inherits from the global container defined in
+				<defaults>.
+
+				NOTE: Your own configurations should be defined in config patch files. See
+				Unicorn.Configs.Default.example for a baseline you can make your own from.
 			-->
 			<configurations>
 			</configurations>
 
-			<!-- 
-				These are the default Unicorn dependency configurations. These affect all configurations,
-				unless specifically overridden in the configuration definition.
-				
-				Each dependency type can have non-dependency constructor params passed to it by adding XML attributes to the
-				main declaration - e.g. <foo type="..." bar="hello"> would pass "hello" to public MyType(string bar)
-				
-				You can also receive any XML body passed to the dependency to a 'configNode' XmlElement parameter.
-				This is how the SerializationPresetPredicate defines its preset.
-				
-				Did you know you can define your own global dependencies and override them in configurations? You can!
+			<!--
+				These are the default Unicorn dependency configurations. These affect all
+				configurations,	unless specifically overridden in the configuration definition.
+
+				Each dependency type can have non-dependency constructor params passed to it by
+				adding XML attributes to the main declaration - e.g. <foo type="..." bar="hello">
+				would pass "hello" to public MyType(string bar)
+
+				You can also receive any XML body passed to the dependency to a 'configNode'
+				XmlElement parameter. This is how the SerializationPresetPredicate defines its
+				preset.
+
+				Did you know you can define your own global dependencies and override them in
+				configurations? You can!
 			-->
 			<defaults>
 				<!-- The source data store is where we read data from. Usually, this would be Sitecore. -->
 				<sourceDataStore type="Rainbow.Storage.Sc.SitecoreDataStore, Rainbow.Storage.Sc" singleInstance="true"/>
 
-				<!-- 
+				<!--
 						The target data store is where we write serialized items to.
-					
+
 						Note the target data store's rootPath can be any of:
 						Absolute filesystem path, e.g. c:\foo\bar
 						Web-root-relative path, e.g. ~/data/serialization or ~/../out-of-root-serialization
 						Data-folder-relative path, e.g. $(dataFolder)\serializedItems
-						DO NOT SHARE A ROOT PATH BETWEEN CONFIGURATIONS (at least if you're using SFS). They can clobber each other's folders.
-						You may inject the name of the current configuration as a variable with $(configurationName)
-					
-						The data cache uses a memory cache to store serialized items read from disk. It is recommended if using transparent syncing for performance. It's not really needed otherwise.
+
+						DO NOT SHARE A ROOT PATH BETWEEN CONFIGURATIONS (at least if you're using SFS).
+						They can clobber each other's folders. You may inject the name of the current
+						configuration as a variable with $(configurationName).
+
+						The data cache uses a memory cache to store serialized items read from disk. It
+						is recommended if using transparent syncing for performance. It's not really
+						needed otherwise.
 					-->
 				<targetDataStore type="Rainbow.Storage.SerializationFileSystemDataStore, Rainbow" physicalRootPath="$(dataFolder)\Unicorn\$(configurationName)" useDataCache="false" singleInstance="true"/>
-				
+
 				<serializationFormatter type="Rainbow.Storage.Yaml.YamlSerializationFormatter, Rainbow.Storage.Yaml" singleInstance="true">
 					<fieldFormatter type="Rainbow.Formatting.FieldFormatters.MultilistFormatter, Rainbow" />
 					<fieldFormatter type="Rainbow.Formatting.FieldFormatters.XmlFieldFormatter, Rainbow" />
 				</serializationFormatter>
-						
+
 				<deserializer type="Rainbow.Storage.Sc.Deserialization.DefaultDeserializer, Rainbow.Storage.Sc" singleInstance="true" />
 					<deserializerLogger type="Unicorn.Deserialization.DefaultDeserializerLogger, Unicorn" singleInstance="true"/>
 
@@ -71,21 +83,24 @@
 
 				<!-- The ItemComparer handles comparing items for the Evaluator and SerializationConflictProcessor -->
 				<itemComparer type="Rainbow.Diff.ItemComparer, Rainbow" singleInstance="true">
-					<!-- 
-					  You may add your own field comparisons here to determine equality - they are evaluated in order and the first one to say it can compare gets the job.
-					  Note: the DefaultComparison, which does a string Equals() comparison, is automatically registered last and does not need to appear here.
+					<!--
+					  You may add your own field comparisons here to determine equality - they are
+					  evaluated in order and the first one to say it can compare gets the job.
+
+					  Note: the DefaultComparison, which does a string Equals() comparison, is
+					  automatically registered last and does not need to appear here.
 					-->
 					<fieldComparer type="Rainbow.Diff.Fields.XmlComparison, Rainbow" />
 					<fieldComparer type="Rainbow.Diff.Fields.MultiLineTextComparison, Rainbow" />
 					<fieldComparer type="Rainbow.Diff.Fields.MultilistComparison, Rainbow" />
 				</itemComparer>
 
-				<!-- there is no default predicate, because this must be configured for each configuration -->
+				<!-- There is no default predicate, because this must be configured for each configuration. -->
 				<predicate type="null"/>
 
-				<!-- 
-					The field filter can be used to ignore fields when comparing or serializing (i.e. don't write them to disk). 
-					Commonly, metadata fields such as Last Updated will be ignored to prevent SCM conflicts. 
+				<!--
+					The field filter can be used to ignore fields when comparing or serializing (i.e. don't write them to disk).
+					Commonly, metadata fields such as Last Updated will be ignored to prevent SCM conflicts.
 				-->
 				<fieldFilter type="Rainbow.Filtering.ConfigurationFieldFilter, Rainbow" singleInstance="true">
 					<exclude fieldID="{B1E16562-F3F9-4DDD-84CA-6E099950ECC0}" note="'Last run' field on Schedule template (used to register tasks)" />
@@ -97,7 +112,7 @@
 					<exclude fieldID="{001DD393-96C5-490B-924A-B0F25CD9EFD8}" note="'__Lock' field on Standard Template" />
 				</fieldFilter>
 
-				<!-- note that the DebugSerializationLoaderLogger is also available if you want more detailed logging and timing information -->
+				<!-- Note that the DebugSerializationLoaderLogger is also available if you want more detailed logging and timing information. -->
 				<loaderLogger type="Unicorn.Loader.DefaultSerializationLoaderLogger, Unicorn" singleInstance="true"/>
 
 				<loaderConsistencyChecker type="Unicorn.Loader.DuplicateIdConsistencyChecker, Unicorn"/>
@@ -121,12 +136,12 @@
 		</unicorn>
 
 		<settings>
-			<!-- 
-				Controls how many threads Unicorn can use when syncing or reserializing. 
+			<!--
+				Controls how many threads Unicorn can use when syncing or reserializing.
 				This value can be set to significantly higher than the number of CPU cores, as these are largely I/O bound.
 				Use fewer threads for HDDs or slow SQL servers, and more threads for SSDs.
 				For a SSD workload on a quad-core CPU 16 seems to be a decent number.
-				
+
 				NOTE: certain older versions of Sitecore 7.x and early versions of 8.0 have a SQL deadlocking issue that can be exposed with high concurrency.
 				If you receive "timed out before getting a connection from the pool" errors when syncing, you may need to upgrade Sitecore
 				or reduce the concurrency to 1 to resolve the issue. All versions of 7.5 have this problem.


### PR DESCRIPTION
- fixed typos and white spaces
- cleaned up line length for comments

(again: I might have overdone it a bit, sorry for not spitting it up into more commits.)