### PR TITLE
Fixed null reference exception when using transparent sync

### DIFF
--- a/src/Unicorn/Data/DataProvider/UnicornSqlServerDataProvider.cs
+++ b/src/Unicorn/Data/DataProvider/UnicornSqlServerDataProvider.cs
@@ -153,7 +153,7 @@ namespace Unicorn.Data.DataProvider
 			if (results.Count == 0)
 			{
 				// get database children
-				var baseIds = base.GetChildIDs(itemDefinition, context);
+				var baseIds = base.GetChildIDs(itemDefinition, context) ?? new IDList();
 
 				// get additional children from Unicorn providers
 				// e.g. for TpSync if the root item of a tree is not in the database


### PR DESCRIPTION
After enabling transparent sync with existing serialized items against an empty Sitecore database, I kept getting null reference exceptions when accessing items in the content editor that did not exist in the database.
Adding this little null fallback in the dataprovider has eliminated the issue completely.