### PR TITLE
LinkDatabase auto update on Sync

### DIFF
--- a/src/Unicorn/Pipelines/UnicornSyncComplete/RebuildLinkDatabaseForSyncedItems.cs
+++ b/src/Unicorn/Pipelines/UnicornSyncComplete/RebuildLinkDatabaseForSyncedItems.cs
@@ -1,0 +1,18 @@
+﻿using Sitecore;
+
+namespace Unicorn.Pipelines.UnicornSyncComplete
+{
+    public class RebuildLinkDatabaseForSyncedItems : IUnicornSyncCompleteProcessor
+    {
+        public void Process(UnicornSyncCompletePipelineArgs args)
+        {
+            foreach (var item in args.Changes)
+            {
+                if (item.ChangeType == ChangeType.Deleted)
+                    Globals.LinkDatabase.RemoveReferences(args.ProcessorItem.InnerItem);
+                else
+                    Globals.LinkDatabase.UpdateReferences(args.ProcessorItem.InnerItem);
+            }
+        }
+    }
+}

--- a/src/Unicorn/Standard Config Files/Unicorn.LinkDatabase.config
+++ b/src/Unicorn/Standard Config Files/Unicorn.LinkDatabase.config
@@ -1,0 +1,18 @@
+<!--
+	Unicorn LinkDatabase Configuration
+
+	This file configures the Unicorn serialization system to automatically keep LinkDatabase references up to date. 
+
+	Disabling this will speed up your sync a bit, but cause internal Sitecore Item referencing to fail.
+
+	http://github.com/kamsar/Unicorn
+-->
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
+	<sitecore>
+		<pipelines>
+			<unicornSyncComplete>
+				<processor type="Unicorn.Pipelines.UnicornSyncComplete.RebuildLinkDatabaseForSyncedItems, Unicorn" />
+			</unicornSyncComplete>
+		</pipelines>
+	</sitecore>
+</configuration>

--- a/src/Unicorn/Unicorn.csproj
+++ b/src/Unicorn/Unicorn.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Pipelines\UnicornReserializeComplete\IUnicornReserializeCompleteProcessor.cs" />
     <Compile Include="Pipelines\UnicornReserializeComplete\UnicornReserializeCompletePipelineArgs.cs" />
     <Compile Include="Pipelines\UnicornSyncComplete\DictionaryCacheClearer.cs" />
+    <Compile Include="Pipelines\UnicornSyncComplete\RebuildLinkDatabaseForSyncedItems.cs" />
     <Compile Include="Predicates\Exclusions\ChildrenOfPathBasedPresetTreeExclusion.cs" />
     <Compile Include="Predicates\Exclusions\PathBasedPresetTreeExclusion.cs" />
     <Compile Include="Predicates\Exclusions\PathTool.cs" />
@@ -212,6 +213,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Standard Config Files\Unicorn.LinkDatabase.config" />
     <None Include="Standard Config Files\Unicorn.Configs.NewItemsOnly.example">
       <SubType>Designer</SubType>
     </None>


### PR DESCRIPTION
LinkDatabase processor and config, to keep LinkDatabase up to date.

Not sure I entirely agree with the disabling of event handlers in general though. They are there for a reason. Is this a global setting actually?  can that behaviour be disabled?