### PR TITLE
Avoid conflict when paths start the same

### DIFF
--- a/src/Unicorn/Predicates/SerializationPresetPredicate.cs
+++ b/src/Unicorn/Predicates/SerializationPresetPredicate.cs
@@ -61,7 +61,8 @@ namespace Unicorn.Predicates
 			if (!itemData.DatabaseName.Equals(entry.DatabaseName, StringComparison.OrdinalIgnoreCase)) return new PredicateResult(false);
 
 			// check for path match
-			if (!itemData.Path.StartsWith(entry.Path, StringComparison.OrdinalIgnoreCase)) return new PredicateResult(false);
+			if (!itemData.Path.StartsWith(entry.Path + "/", StringComparison.OrdinalIgnoreCase) 
+                && !itemData.Path.Equals(entry.Path, StringComparison.OrdinalIgnoreCase)) return new PredicateResult(false);
 
 			// check excludes
 			return ExcludeMatches(entry, itemData);


### PR DESCRIPTION
Serializing could result in `No trees contained the global path /sitecore/templates/YourPath` if two configurations included a path that starts with the same string.  
For example, `/sitecore/templates/YourPath` and `/sitecore/templates/YourPathHere` could cause a conflict.  

For some reason none of the unit tests are running on my machine so please run them before accepting.