### PR TITLE
Expanded Content Editor warnings to include name of PredicateTreeRoot…

### DIFF
--- a/src/Unicorn/Predicates/PredicateResult.cs
+++ b/src/Unicorn/Predicates/PredicateResult.cs
@@ -15,5 +15,6 @@
 
 		public bool IsIncluded { get; private set; }
 		public string Justification { get; private set; }
+		public PresetTreeRoot PresetTreeRoot { get; set; }
 	}
 }

--- a/src/Unicorn/Predicates/SerializationPresetPredicate.cs
+++ b/src/Unicorn/Predicates/SerializationPresetPredicate.cs
@@ -40,7 +40,11 @@ namespace Unicorn.Predicates
 			{
 				result = Includes(entry, itemData);
 
-				if (result.IsIncluded) return result; // it's definitely included if anything includes it
+				if (result.IsIncluded)
+				{
+					result.PresetTreeRoot = entry;
+					return result; // it's definitely included if anything includes it
+				}
 				if (!string.IsNullOrEmpty(result.Justification)) priorityResult = result; // a justification means this is probably a more 'important' fail than others
 			}
 


### PR DESCRIPTION
… the item is included by.

As per discussion on #unicorn Slack today.

Basically; having the name of the Predicate Tree Root that included the item would be useful information to get in the Content Editor Warning. It will only show under DevMode settings.
