### PR TITLE
Added TemplateBasedPresetExclusion

### DIFF
--- a/src/Unicorn.Tests/Predicates/SerializationPresetPredicateTests.cs
+++ b/src/Unicorn.Tests/Predicates/SerializationPresetPredicateTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Xml;
 using FluentAssertions;
@@ -37,6 +38,11 @@ namespace Unicorn.Tests.Predicates
 		[InlineData("/implicit-nochildren/ignoredchild", false)]
 		[InlineData("/implicit-nochildren/ignored/stillignored", false)]
 		[InlineData("/implicit-nochildrenwithextrachars", false)]
+		// TEMPLATE-ID test config
+		[InlineData("/sitecore/allowed", true)]
+		[InlineData("/sitecore/allowed/child", true)]
+		[InlineData("/sitecore/excluded", false)]
+		[InlineData("/sitecore/excluded/nochildrenwithexcludedparent", false)]
 		// SOME-CHILDREN test config
 		[InlineData("/somechildren", true)]
 		[InlineData("/somechildren/ignoredchild", false)]
@@ -113,11 +119,15 @@ namespace Unicorn.Tests.Predicates
 
 			var roots = predicate.GetRootPaths();
 
-			roots.Length.Should().Be(11);
-			roots[0].DatabaseName.Should().Be("master");
-			roots[0].Path.Should().Be("/sitecore/layout/Simulators");
-			roots[7].DatabaseName.Should().Be("core");
-			roots[7].Path.Should().Be("/sitecore/coredb");
+			roots.Length.Should().Be(13);
+
+			var basicRoot = roots.FirstOrDefault(root => root.Name.Equals("Basic"));
+			basicRoot?.DatabaseName.Should().Be("master");
+			basicRoot?.Path.Should().Be("/sitecore/layout/Simulators");
+
+			var dbTestRoot = roots.FirstOrDefault(root => root.Name.Equals("DB test"));
+			dbTestRoot?.DatabaseName.Should().Be("core");
+			dbTestRoot?.Path.Should().Be("/sitecore/coredb");
 		}
 
 		private SerializationPresetPredicate CreateTestPredicate(XmlNode configNode)
@@ -142,9 +152,9 @@ namespace Unicorn.Tests.Predicates
 			return doc.DocumentElement;
 		}
 
-		private IItemData CreateTestItem(string path, string database = "master")
+		private IItemData CreateTestItem(string path, string database = "master", string templateId = "{11111111-1111-1111-1111-111111111111}")
 		{
-			return new ProxyItem { Path = path, DatabaseName = database };
+			return new ProxyItem { Path = path, DatabaseName = database, TemplateId = new Guid(templateId) };
 		}
 	}
 }

--- a/src/Unicorn.Tests/Predicates/TestConfiguration.xml
+++ b/src/Unicorn.Tests/Predicates/TestConfiguration.xml
@@ -25,6 +25,18 @@
 		<exclude path="/implicit-nochildren/" /> <!-- implicit exclusion of a child path. NOTE: does not work for paths under the root (e.g. /implicit-nochildren/foo/) -->
 	</include>
 
+  <!-- 
+		TEMPLATE-ID: Exclude all children with a given templateId		
+		NOTE: children of items with the excluded template ID will also be excluded
+	-->
+  <include name="Template ID" database="master" path="/sitecore/allowed">
+    <exclude templateId="{3B4F2B85-778D-44F3-9B2D-BEFF1F3575E6}" />
+  </include>
+
+  <include name="Template ID - exclude" database="master" path="/sitecore/excluded">
+    <exclude templateId="{11111111-1111-1111-1111-111111111111}" /> <!--all test items are created with the following templateId-->
+  </include>  
+  
 	<!-- 
 		SOME-CHILDREN: Include parent, exclude all children EXCEPT for specific ones
 	-->

--- a/src/Unicorn/Predicates/Exclusions/ChildrenOfPathBasedPresetTreeExclusion.cs
+++ b/src/Unicorn/Predicates/Exclusions/ChildrenOfPathBasedPresetTreeExclusion.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Rainbow.Model;
 
 namespace Unicorn.Predicates.Exclusions
 {
@@ -29,9 +30,9 @@ namespace Unicorn.Predicates.Exclusions
 			_exceptions = exceptions.Select(exception => $"{PathTool.EnsureTrailingSlash(_excludeChildrenOfPath)}{exception}/").ToArray();
 		}
 
-		public PredicateResult Evaluate(string itemPath)
+		public PredicateResult Evaluate(IItemData itemData)
 		{
-			itemPath = PathTool.EnsureTrailingSlash(itemPath);
+			var itemPath = PathTool.EnsureTrailingSlash(itemData.Path);
 
 			// you may preserve certain children from exclusion
 			foreach (var exception in _exceptions)

--- a/src/Unicorn/Predicates/Exclusions/PathBasedPresetTreeExclusion.cs
+++ b/src/Unicorn/Predicates/Exclusions/PathBasedPresetTreeExclusion.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Rainbow.Model;
 
 namespace Unicorn.Predicates.Exclusions
 {
@@ -28,9 +29,9 @@ namespace Unicorn.Predicates.Exclusions
 			_excludedPath = PathTool.EnsureTrailingSlash(_excludedPath);
 		}
 
-		public PredicateResult Evaluate(string itemPath)
+		public PredicateResult Evaluate(IItemData itemData)
 		{
-			itemPath = PathTool.EnsureTrailingSlash(itemPath);
+			var itemPath = PathTool.EnsureTrailingSlash(itemData.Path);
 
 			bool result = itemPath.StartsWith(_excludedPath, StringComparison.OrdinalIgnoreCase);
 

--- a/src/Unicorn/Predicates/Exclusions/TemplateBasedPresetExclusion.cs
+++ b/src/Unicorn/Predicates/Exclusions/TemplateBasedPresetExclusion.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Rainbow.Model;
+
+namespace Unicorn.Predicates.Exclusions
+{
+	/// <summary>
+	/// Excludes items with a given template ID
+	/// e.g. <exclude templateId="{3B4F2B85-778D-44F3-9B2D-BEFF1F3575E6}" /> in config
+	/// </summary>
+	public class TemplateBasedPresetExclusion : IPresetTreeExclusion
+	{
+		private readonly string _excludedTemplate;
+
+		public TemplateBasedPresetExclusion(string templateId, PresetTreeRoot root)
+		{
+			_excludedTemplate = templateId;
+		}
+
+		public string Description => $"items with template id: {_excludedTemplate}";
+
+		public PredicateResult Evaluate(IItemData itemData)
+		{
+			if (itemData.TemplateId.Equals(new Guid(_excludedTemplate)))
+			{
+				return new PredicateResult($"Item template id exclusion rule: {_excludedTemplate}");
+			}
+			return new PredicateResult(true);
+		}
+	}
+}

--- a/src/Unicorn/Predicates/IPresetTreeExclusion.cs
+++ b/src/Unicorn/Predicates/IPresetTreeExclusion.cs
@@ -1,8 +1,10 @@
-﻿namespace Unicorn.Predicates
+﻿using Rainbow.Model;
+
+namespace Unicorn.Predicates
 {
 	public interface IPresetTreeExclusion
 	{
-		PredicateResult Evaluate(string itemPath);
+		PredicateResult Evaluate(IItemData itemData);
 		string Description { get; }
 	}
 }

--- a/src/Unicorn/Predicates/SerializationPresetPredicate.cs
+++ b/src/Unicorn/Predicates/SerializationPresetPredicate.cs
@@ -81,7 +81,7 @@ namespace Unicorn.Predicates
 		{
 			foreach (var exclude in entry.Exclusions)
 			{
-				var result = exclude.Evaluate(itemData.Path);
+				var result = exclude.Evaluate(itemData);
 
 				if (!result.IsIncluded) return result;
 			}
@@ -180,6 +180,11 @@ namespace Unicorn.Predicates
 			if (excludeNode.HasAttribute("path"))
 			{
 				return new PathBasedPresetTreeExclusion(GetExpectedAttribute(excludeNode, "path"), root);
+			}
+
+			if (excludeNode.HasAttribute("templateId"))
+			{
+				return new TemplateBasedPresetExclusion(GetExpectedAttribute(excludeNode, "templateId"), root);
 			}
 
 			var exclusions = excludeNode.ChildNodes

--- a/src/Unicorn/Unicorn.csproj
+++ b/src/Unicorn/Unicorn.csproj
@@ -178,6 +178,7 @@
     <Compile Include="PowerShell\SyncUnicornItemCommand.cs" />
     <Compile Include="PowerShell\SyncUnicornConfigurationCommand.cs" />
     <Compile Include="PowerShell\YamlCommandBase.cs" />
+    <Compile Include="Predicates\Exclusions\TemplateBasedPresetExclusion.cs" />
     <Compile Include="Predicates\Exclusions\ChildrenOfPathBasedPresetTreeExclusion.cs" />
     <Compile Include="Predicates\Exclusions\PathBasedPresetTreeExclusion.cs" />
     <Compile Include="Predicates\Exclusions\PathTool.cs" />


### PR DESCRIPTION
This pull request brings support for template id exlusions

Example configuration:
```xml
<include database="master" path="/sitecore/media library/Default Website">
	<exclude templateId="{3B4F2B85-778D-44F3-9B2D-BEFF1F3575E6}" />
</include>
```
Originally implemented [here](https://alan-null.github.io/2017/03/custom-unicorn-predicate)