### PR TITLE
Support Sitecore unit testing mode

### DIFF
--- a/src/Unicorn.Roles/Data/FilesystemRoleDataStore.cs
+++ b/src/Unicorn.Roles/Data/FilesystemRoleDataStore.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Web.Hosting;
 using Sitecore.Diagnostics;
@@ -87,7 +88,11 @@ namespace Unicorn.Roles.Data
 		{
 			if (rootPath.StartsWith("~") || rootPath.StartsWith("/"))
 			{
-				rootPath = HostingEnvironment.MapPath("~/") + rootPath.Substring(1).Replace("/", Path.DirectorySeparatorChar.ToString());
+				// Support unit testing scenario where hosting environment is not initialized.
+				var hostingRoot = HostingEnvironment.IsHosted
+					? HostingEnvironment.MapPath("~/")
+					: AppDomain.CurrentDomain.BaseDirectory;
+			    return Path.Combine(hostingRoot, rootPath.Substring(1).Replace("/", Path.DirectorySeparatorChar.ToString()));
 			}
 
 			if (!Directory.Exists(rootPath)) Directory.CreateDirectory(rootPath);

--- a/src/Unicorn.Users/Data/FilesystemUserDataStore.cs
+++ b/src/Unicorn.Users/Data/FilesystemUserDataStore.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Web.Hosting;
 using Sitecore.Diagnostics;
@@ -85,7 +86,11 @@ namespace Unicorn.Users.Data
 		{
 			if (rootPath.StartsWith("~") || rootPath.StartsWith("/"))
 			{
-				rootPath = HostingEnvironment.MapPath("~/") + rootPath.Substring(1).Replace("/", Path.DirectorySeparatorChar.ToString());
+				// Support unit testing scenario where hosting environment is not initialized.
+				var hostingRoot = HostingEnvironment.IsHosted
+					? HostingEnvironment.MapPath("~/")
+					: AppDomain.CurrentDomain.BaseDirectory;
+			    return Path.Combine(hostingRoot, rootPath.Substring(1).Replace("/", Path.DirectorySeparatorChar.ToString()));
 			}
 
 			if (!Directory.Exists(rootPath)) Directory.CreateDirectory(rootPath);

--- a/src/Unicorn/Configuration/ConfigurationUtility.cs
+++ b/src/Unicorn/Configuration/ConfigurationUtility.cs
@@ -1,4 +1,8 @@
-﻿namespace Unicorn.Configuration
+﻿using System;
+using System.IO;
+using System.Web.Hosting;
+
+namespace Unicorn.Configuration
 {
 	internal static class ConfigurationUtility
 	{
@@ -9,9 +13,14 @@
 		{
 			if (configPath.StartsWith("~/"))
 			{
-				return System.Web.Hosting.HostingEnvironment.MapPath("~") + configPath.Substring(2).Replace('/', '\\');
 				// +1 to Stack Overflow:
 				// http://stackoverflow.com/questions/4742257/how-to-use-server-mappath-when-httpcontext-current-is-nothing
+
+				// Support unit testing scenario where hosting environment is not initialized.
+				var hostingRoot = HostingEnvironment.IsHosted
+					? HostingEnvironment.MapPath("~/")
+					: AppDomain.CurrentDomain.BaseDirectory;
+				return Path.Combine(hostingRoot, configPath.Substring(2).Replace('/', '\\'));
 			}
 
 			return configPath;


### PR DESCRIPTION
When 'unittesting' Sitecore, no hosting environment is available. Allow resolving paths in that case by using the appdomain base directory as root folder.