### PR TITLE
Remove check of CreationDate for users

### DIFF
--- a/src/Unicorn.Users/Loader/UserLoader.cs
+++ b/src/Unicorn.Users/Loader/UserLoader.cs
@@ -97,7 +97,6 @@ namespace Unicorn.Users.Loader
 				if (!existingUser.Email.Equals(updatedUser.Email)) changes.Add(new UserUpdate("Email", existingUser.Email, updatedUser.Email));
 				if (!existingUser.Comment.Equals(updatedUser.Comment)) changes.Add(new UserUpdate("Comment", existingUser.Comment, updatedUser.Comment));
 				if (!existingUser.IsApproved.Equals(updatedUser.IsApproved)) changes.Add(new UserUpdate("IsApproved", existingUser.IsApproved.ToString(), updatedUser.IsApproved.ToString()));
-				if (!existingUser.CreationDate.Equals(updatedUser.CreationDate.ToUniversalTime())) changes.Add(new UserUpdate("CreationDate", existingUser.CreationDate.ToString(CultureInfo.InvariantCulture), updatedUser.CreationDate.ToUniversalTime().ToString(CultureInfo.InvariantCulture) + " (UTC)"));
 			}
 
 			Membership.UpdateUser(updatedUser);


### PR DESCRIPTION
At the moment, when I sync users, I get a message telling me that the CreationDate has been updated for every single one. 

```
[U] User XXXXXX
* [U] CreationDate updated from 07/04/2017 11:32:31 to 07/04/2017 15:23:39 (UTC).
```

This persists between syncs, as the Membership.UpdateUser call does not update the CreationDate.
I've removed the message to prevent the sync logs from filling up. 