### PR TITLE
Ensuring that an automated tool doesn't get redirected to a Sitecore …

### DIFF
--- a/src/Unicorn/ControlPanel/Pipelines/UnicornControlPanelRequest/UnicornControlPanelRequestPipelineProcessor.cs
+++ b/src/Unicorn/ControlPanel/Pipelines/UnicornControlPanelRequest/UnicornControlPanelRequestPipelineProcessor.cs
@@ -20,7 +20,15 @@ namespace Unicorn.ControlPanel.Pipelines.UnicornControlPanelRequest
 		{
 			bool handled = HandlesVerb(args);
 
-			if (!handled) return;
+			if (!handled)
+			{
+				if (_verbHandled.Equals(args.Verb ?? string.Empty, StringComparison.OrdinalIgnoreCase) && !args.SecurityState.IsAllowed && args.SecurityState.IsAutomatedTool)
+				{
+					args.Response = new PlainTextResponse("Unable to authorize request, ensure that your shared secrets match.", System.Net.HttpStatusCode.Forbidden);
+					args.AbortPipeline();
+				}
+				return;
+			}
 
 			args.Response = CreateResponse(args);
 


### PR DESCRIPTION
…login page, but instead gets a 403 error

You can test this by using the powershell module to sync with a bad shared secret.