### PR TITLE
Add namePattern parameter to <include>

### DIFF
--- a/src/Unicorn.Tests/Predicates/SerializationPresetPredicateTests.cs
+++ b/src/Unicorn.Tests/Predicates/SerializationPresetPredicateTests.cs
@@ -29,6 +29,12 @@ namespace Unicorn.Tests.Predicates
 		[InlineData("/sitecore/layout/Simulators/iPhone", false)]
 		[InlineData("/sitecore/layout/Simulators/iPhone Apps", true)] // path starts with excluded iPhone path but is not equal
 		[InlineData("/sitecore/layout/Simulators/iPhone Apps/1.0", false)]
+		// INCLUDE NAMEPATTERN test config (rocket|unicorn)
+		[InlineData("/includenamepattern/unicorn", true)]
+		[InlineData("/includenamepattern/ninja", false)]
+		[InlineData("/includenamepattern/ninja unicorn", true)]
+		[InlineData("/includenamepattern/rocket", true)]
+		[InlineData("/includenamepattern/rocket unicorn", true)]
 		// EXPLICIT NO-CHILDREN test config
 		[InlineData("/nochildren", true)]
 		[InlineData("/nochildren/ignoredchild", false)]
@@ -156,7 +162,7 @@ namespace Unicorn.Tests.Predicates
 
 			var roots = predicate.GetRootPaths();
 
-			roots.Length.Should().Be(16);
+			roots.Length.Should().Be(17);
 
 			var basicRoot = roots.FirstOrDefault(root => root.Name.Equals("Basic"));
 			basicRoot?.DatabaseName.Should().Be("master");

--- a/src/Unicorn.Tests/Predicates/SerializationPresetPredicateTests.cs
+++ b/src/Unicorn.Tests/Predicates/SerializationPresetPredicateTests.cs
@@ -32,9 +32,9 @@ namespace Unicorn.Tests.Predicates
 		// INCLUDE NAMEPATTERN test config (rocket|unicorn)
 		[InlineData("/includenamepattern/unicorn", true)]
 		[InlineData("/includenamepattern/ninja", false)]
-		[InlineData("/includenamepattern/ninja unicorn", true)]
+		[InlineData("/includenamepattern/ninja unicorn", false)]
 		[InlineData("/includenamepattern/rocket", true)]
-		[InlineData("/includenamepattern/rocket unicorn", true)]
+		[InlineData("/includenamepattern/rocket unicorn", false)]
 		// EXPLICIT NO-CHILDREN test config
 		[InlineData("/nochildren", true)]
 		[InlineData("/nochildren/ignoredchild", false)]

--- a/src/Unicorn.Tests/Predicates/TestConfiguration.xml
+++ b/src/Unicorn.Tests/Predicates/TestConfiguration.xml
@@ -11,6 +11,11 @@
 		<exclude path="iPhone Apps/1.0" />
 		<!-- exclude where name starts with a different include -->
 	</include>
+	
+	<!--
+		INCLUDE NAMEPATTERN: Include only items matching the pattern within the path
+	-->
+	<include name="Include NamePattern" database="master" path="/includenamepattern" namePattern="(rocket|unicorn)" />
 
 	<!-- 
 		EXPLICIT NO-CHILDREN: Include parent, but exclude children test

--- a/src/Unicorn/Predicates/PresetTreeRoot.cs
+++ b/src/Unicorn/Predicates/PresetTreeRoot.cs
@@ -12,6 +12,13 @@ namespace Unicorn.Predicates
 			if (name == null) Name = path.Substring(path.LastIndexOf('/') + 1);
 		}
 
+		public PresetTreeRoot(string name, string path, string databaseName, string namePattern) : base(name, path, databaseName, namePattern)
+		{
+			Exclusions = new List<IPresetTreeExclusion>();
+
+			if (name == null) Name = path.Substring(path.LastIndexOf('/') + 1);
+		}
+
 		public IList<IPresetTreeExclusion> Exclusions { get; set; }
 	}
 }

--- a/src/Unicorn/Predicates/SerializationPresetPredicate.cs
+++ b/src/Unicorn/Predicates/SerializationPresetPredicate.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml;
 using Rainbow.Model;
 using Rainbow.Storage;
@@ -71,6 +72,14 @@ namespace Unicorn.Predicates
 			if (!itemData.Path.StartsWith(unescapedPath + "/", StringComparison.OrdinalIgnoreCase) && !itemData.Path.Equals(unescapedPath, StringComparison.OrdinalIgnoreCase))
 			{
 				return new PredicateResult(false);
+			}
+
+			// check for include match
+			if (!string.IsNullOrEmpty(entry.NamePattern))
+			{
+				var regexPattern = new Regex(entry.NamePattern, RegexOptions.IgnoreCase);
+				if (!regexPattern.IsMatch(itemData.Name))
+					return new PredicateResult(false);
 			}
 
 			// check excludes
@@ -163,8 +172,13 @@ namespace Unicorn.Predicates
 			// ReSharper disable once PossibleNullReferenceException
 			var name = configuration.Attributes["name"];
 			string nameValue = name == null ? path.Substring(path.LastIndexOf('/') + 1) : name.Value;
+			
+			var namePattern = configuration.Attributes["namePattern"];
+			string namePatternValue = namePattern == null ? string.Empty : namePattern.Value;
 
-			var root = new PresetTreeRoot(nameValue, path, database);
+			var root = string.IsNullOrEmpty(namePatternValue)
+				? new PresetTreeRoot(nameValue, path, database)
+				: new PresetTreeRoot(nameValue, path, database, namePatternValue);
 
 			root.Exclusions = configuration.ChildNodes
 				.OfType<XmlElement>()

--- a/src/Unicorn/Predicates/SerializationPresetPredicate.cs
+++ b/src/Unicorn/Predicates/SerializationPresetPredicate.cs
@@ -77,7 +77,7 @@ namespace Unicorn.Predicates
 			// check for include match
 			if (!string.IsNullOrEmpty(entry.NamePattern))
 			{
-				var regexPattern = new Regex(entry.NamePattern, RegexOptions.IgnoreCase);
+				var regexPattern = new Regex($"^{entry.NamePattern}$", RegexOptions.IgnoreCase);
 				if (!regexPattern.IsMatch(itemData.Name))
 					return new PredicateResult(false);
 			}


### PR DESCRIPTION
As discussed in Slack, added the ability to use namePattern as an inclusion criteria, example:
`<include name="Include NamePattern" database="master" path="/includenamepattern" namePattern="(rocket|unicorn)" />`